### PR TITLE
fix typo in README

### DIFF
--- a/jigg/README.md
+++ b/jigg/README.md
@@ -63,7 +63,7 @@ node demo/party.js 3000 Evaluator 00000000000000000000000000000000 hex aes-128-r
 
 ### Server + Garbler/Evaluator
 
-The server may also run as a garbler or evaluator. You can acheive this by running the server with
+The server may also run as a garbler or evaluator. You can achieve this by running the server with
 the same arguments as a party:
 ```shell
 node demo/server.js <port> <role> <input> <encoding> <circuitName>


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the README file, changing "acheive" to the correct spelling "achieve" in the section describing how to run the server as a garbler or evaluator. No other changes were made. This improves the documentation's clarity and professionalism.
